### PR TITLE
Fix a type in "Example 14 - Rate Limiting" in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1224,7 +1224,7 @@ buffering our limiter channel. This `burstyLimiter`
 channel will allow bursts of up to 3 events.
 
 ```swift
-let burstyLimiter = Channel<Int>(bufferSize: 3)
+let burstyLimiter = Channel<Int64>(bufferSize: 3)
 ```
 
 Fill up the channel to represent allowed bursting.


### PR DESCRIPTION
### Problem

The burst example in README got "Binary operator '<-' cannot be applied to operands of type 'Channel&lt;Int&gt;' and 'Int64'" because the type mismatch of the `Int` channel and `now` and `time` generated from `Ticker` channel as `Int64`.

```
let burstyLimiter = Channel<Int>(bufferSize: 3)

for _ in 0 ..< 3 {
    burstyLimiter <- now // Compiler error here. now is Int64.
}

co {
    for time in Ticker(period: 200 * millisecond).channel {
        burstyLimiter <- time // Compiler error here. time is Int64.
    }
}
```

### Fix

Changed the type of the channel to `Int64`.

### Environment

- Venice 0.9
- Xcode 7.1.1
- OS X 10.11.1