### PR TITLE
Stop using deprecated increment/decrement operators

### DIFF
--- a/Source/TCPServerSocket.swift
+++ b/Source/TCPServerSocket.swift
@@ -116,7 +116,7 @@ extension TCPServerSocket {
                 sequentialErrorsCount = 0
                 co(accepted(clientSocket))
             } catch {
-                ++sequentialErrorsCount
+                sequentialErrorsCount += 1
                 if sequentialErrorsCount >= 10 {
                     throw error
                 }


### PR DESCRIPTION
Recent Swift compiler snapshots emit deprecation warnings for this.