### PR TITLE
Ticker should produce Double instead of Void

### DIFF
--- a/Sources/Venice/Ticker/Ticker.swift
+++ b/Sources/Venice/Ticker/Ticker.swift
@@ -1,8 +1,8 @@
 public final class Ticker {
-    private let internalChannel = Channel<Void>()
+    private let internalChannel = Channel<Double>()
     private var stopped: Bool = false
 
-    public var channel: ReceivingChannel<Void> {
+    public var channel: ReceivingChannel<Double> {
         return internalChannel.receivingChannel
     }
 
@@ -11,7 +11,7 @@ public final class Ticker {
             while true {
                 nap(for: period)
                 if self.stopped { break }
-                self.internalChannel.send(Void())
+                self.internalChannel.send(now())
             }
         }
     }

--- a/Tests/VeniceTests/Venice/TickerTests.swift
+++ b/Tests/VeniceTests/Venice/TickerTests.swift
@@ -5,7 +5,11 @@ public class TickerTests : XCTestCase {
     func testTicker() {
         let ticker = Ticker(period: 10.milliseconds)
         co {
-            for _ in ticker.channel {}
+            var last: Double = 0
+            for time in ticker.channel {
+                XCTAssertTrue(time - last >= Double(0))
+                last = time
+            }
         }
         nap(for: 100.milliseconds)
         ticker.stop()


### PR DESCRIPTION
Hi, it looks like this small feature from previous PR was accidentally reverted during a large refactoring. Here it is resubmitted.

Cheers