### PR TITLE
Added better code coverage for FileDescriptor tests

### DIFF
--- a/Sources/FileDescriptor.swift
+++ b/Sources/FileDescriptor.swift
@@ -41,7 +41,7 @@ public final class FileDescriptor {
         }
         // Error checking here is unecessary. If the file descriptor is invalid,
         // it was caught by the previous statement.
-        fcntl(handle, F_SETFL, flags | O_NONBLOCK)
+        let _ = fcntl(handle, F_SETFL, flags | O_NONBLOCK)
         self.handle = handle
     }
     

--- a/Sources/FileDescriptor.swift
+++ b/Sources/FileDescriptor.swift
@@ -36,15 +36,12 @@ public final class FileDescriptor {
     ///   Thrown when the operation is performed on an invalid file descriptor.
     public init(_ handle: Handle) throws {
         let flags = fcntl(handle, F_GETFL, 0)
-
         guard flags != -1 else {
             throw VeniceError.invalidFileDescriptor
         }
-
-        guard fcntl(handle, F_SETFL, flags | O_NONBLOCK) == 0 else {
-            throw VeniceError.invalidFileDescriptor
-        }
-        
+        // Error checking here is unecessary. If the file descriptor is invalid,
+        // it was caught by the previous statement.
+        fcntl(handle, F_SETFL, flags | O_NONBLOCK)
         self.handle = handle
     }
     

--- a/Tests/VeniceTests/Venice/CoroutineTests.swift
+++ b/Tests/VeniceTests/Venice/CoroutineTests.swift
@@ -7,7 +7,7 @@
 import XCTest
 @testable import Venice
 
-public class CoroutineTests : XCTestCase {    
+public class CoroutineTests : XCTestCase {
     func testCoroutine() throws {
         var sum = 0
 
@@ -227,6 +227,18 @@ public class CoroutineTests : XCTestCase {
 
     func testCleanInvalidHandle() {
         FileDescriptor.clean(-1)
+    }
+
+    func testInvalidWrite() {
+        let handle = open("/dev/null", O_RDONLY)
+        let fildes = try! FileDescriptor(handle)
+        let mutableBuf = UnsafeMutableRawBufferPointer.allocate(count: 1)
+        mutableBuf[0] = 42
+        let buf = UnsafeRawBufferPointer(mutableBuf)
+        XCTAssertThrowsError(
+          try fildes.write(buf, deadline: 1.second.fromNow()),
+          error: VeniceError.writeFailed
+        )
     }
 }
 

--- a/Tests/VeniceTests/Venice/CoroutineTests.swift
+++ b/Tests/VeniceTests/Venice/CoroutineTests.swift
@@ -271,6 +271,10 @@ extension CoroutineTests {
             ("testFileDescriptorBlockedInAnotherCoroutine", testFileDescriptorBlockedInAnotherCoroutine),
             ("testDetachFileDescriptor", testDetachFileDescriptor),
             ("testStandardStreams", testStandardStreams),
+            ("testReadUsingEmptyBuffer", testReadUsingEmptyBuffer),
+            ("testReadFromEmptyFildes", testReadFromEmptyFildes),
+            ("testCleanInvalidHandle", testCleanInvalidHandle),
+            ("testInvalidWrite", testInvalidWrite)
         ]
     }
 }

--- a/Tests/VeniceTests/Venice/CoroutineTests.swift
+++ b/Tests/VeniceTests/Venice/CoroutineTests.swift
@@ -209,12 +209,21 @@ public class CoroutineTests : XCTestCase {
         XCTAssertEqual(try error.detach(), STDERR_FILENO)
     }
 
-    func testReadFromEmptyFileDescriptor() throws {
+    func testReadUsingEmptyBuffer() throws {
         let socketPair = try createSocketPair()
         let buf = UnsafeMutableRawBufferPointer.allocate(count: 0)
         let ret = try socketPair.0.read(buf, deadline: 1.second.fromNow())
         XCTAssert(ret.isEmpty)
     }
+
+    func testReadFromEmptyFildes() throws {
+        let socketPair = try createSocketPair()
+        let buf = UnsafeMutableRawBufferPointer.allocate(count: Int(BUFSIZ))
+        XCTAssertThrowsError(
+          try socketPair.0.read(buf, deadline: 1.second.fromNow()),
+          error: VeniceError.deadlineReached
+        )
+    } 
 }
 
 func createSocketPair() throws -> (FileDescriptor, FileDescriptor) {

--- a/Tests/VeniceTests/Venice/CoroutineTests.swift
+++ b/Tests/VeniceTests/Venice/CoroutineTests.swift
@@ -208,6 +208,13 @@ public class CoroutineTests : XCTestCase {
         XCTAssertEqual(try output.detach(), STDOUT_FILENO)
         XCTAssertEqual(try error.detach(), STDERR_FILENO)
     }
+
+    func testReadFromEmptyFileDescriptor() throws {
+        let socketPair = try createSocketPair()
+        let buf = UnsafeMutableRawBufferPointer.allocate(count: 0)
+        let ret = try socketPair.0.read(buf, deadline: 1.second.fromNow())
+        XCTAssert(ret.isEmpty)
+    }
 }
 
 func createSocketPair() throws -> (FileDescriptor, FileDescriptor) {

--- a/Tests/VeniceTests/Venice/CoroutineTests.swift
+++ b/Tests/VeniceTests/Venice/CoroutineTests.swift
@@ -223,7 +223,11 @@ public class CoroutineTests : XCTestCase {
           try socketPair.0.read(buf, deadline: 1.second.fromNow()),
           error: VeniceError.deadlineReached
         )
-    } 
+    }
+
+    func testCleanInvalidHandle() {
+        FileDescriptor.clean(-1)
+    }
 }
 
 func createSocketPair() throws -> (FileDescriptor, FileDescriptor) {


### PR DESCRIPTION
# Summary

- Added extra test scenarios for better code coverage for FileDescriptor class. 
- Changed a small error checking in _init_ that was unnecessary since the file descriptor was already tested  few lines before.
