### PR TITLE
Cancel notification

### DIFF
--- a/Sources/Coroutine.swift
+++ b/Sources/Coroutine.swift
@@ -40,6 +40,16 @@ import CLibdill
 public final class Coroutine {
     private typealias Handle = Int32
     private let handle: Handle
+    private var cancelled = true
+
+    /// Termination handler. You should set this if you want to execute any
+    /// house keeping or react to a coroutine termination. This is called after
+    /// the coroutine is ended or when it is terminated.
+    ///
+    /// - Parameters:
+    ///   - cancelled: True if the coroutine is being cancelled. False, if it is
+    ///     terminating gracefully.
+    public var terminationHandler: ((Bool)->())?
     
     /// Launches a coroutine that executes the closure passed as argument.
     /// The coroutine is executed concurrently, and its lifetime may exceed the lifetime
@@ -93,6 +103,7 @@ public final class Coroutine {
     }
     
     deinit {
+        cancelled = false
         cancel()
     }
     
@@ -102,6 +113,8 @@ public final class Coroutine {
     /// Once a coroutine is canceled any coroutine-blocking operation within the coroutine
     /// will throw `VeniceError.canceledCoroutine`.
     public func cancel() {
+        terminationHandler?(cancelled)
+        terminationHandler = nil
         hclose(handle)
     }
     

--- a/Tests/VeniceTests/Venice/CoroutineTests.swift
+++ b/Tests/VeniceTests/Venice/CoroutineTests.swift
@@ -225,14 +225,17 @@ public class CoroutineTests : XCTestCase {
     }
 
     func testCancelledTerminationHandler() {
-        var stop = false
         let coroutine = try? Coroutine {
+            var stop = false
             while !stop {
-                try? Coroutine.yield()
+                do {
+                    try Coroutine.yield()
+                } catch {
+                    stop = true
+                }
             }
         }
         coroutine?.terminationHandler = { (cancelled: Bool) in
-            stop = true
             XCTAssertEqual(cancelled, true, "Wrong cancellation behavior")
         }
         try? Coroutine.wakeUp(1.second.fromNow())


### PR DESCRIPTION
# Summary

Added the ability to a coroutine to call a custom handle when it is cancelled or terminated. It is important to give the ability to a programmer to respond to a coroutine cancellation/end of execution since it can add a lot of flexibility.

# Design decisions

The handle is a simples closure that receives as parameter a boolean value. If true, the coroutine was cancelled. Otherwise, it is terminating gracefully.

The handle will be called immediately before the coroutine handle is called. So, the coroutine have the ability to end gracefully.